### PR TITLE
fix: only apply environment filter if value is set

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -482,12 +482,15 @@ func main(cmd *cobra.Command, args []string) error {
 				errGroup.Go(func() error {
 					defer sem.Release(1)
 
-					// check the terragrunt path contains the environment variable value
-					exactEnvironment := fmt.Sprint("/(", environment, ")/")
-					exactEnvironmentRegexp := regexp.MustCompile(exactEnvironment)
-					environmentDoesNotMatchPath := !exactEnvironmentRegexp.Match([]byte(terragruntPath))
-					if environmentDoesNotMatchPath {
-						return nil
+					// only run this check if the environment is given, else generate it for all
+					if environment != "" {
+						// check the terragrunt path contains the environment variable value
+						exactEnvironment := fmt.Sprint("/(", environment, ")/")
+						exactEnvironmentRegexp := regexp.MustCompile(exactEnvironment)
+						environmentDoesNotMatchPath := !exactEnvironmentRegexp.Match([]byte(terragruntPath))
+						if environmentDoesNotMatchPath {
+							return nil
+						}
 					}
 
 					project, err := createProject(terragruntPath)


### PR DESCRIPTION
I was running into a problem where running this within a GitLab Pipeline (in an Alpine container) resulted in it only logging "Working directory: ..." and doing nothing else. 
Locally (on Ubuntu) this generates just fine. Strangely, with a freshly compiled module on `main` results in the same behavior there.

Upon further investigation it showed that it was due to this particular check.  

This check probably should skip this if the environment hasn't been set, so that it will generate it for the entire Terragrunt project (and all environments in it).