### PR TITLE
feat: add grouped resources item

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -72,6 +72,8 @@ type DependencyDirs struct {
 	SourcePath string
 	// List of releative path dependencies
 	Dependencies []string
+	// Dependencies grouped by directory (environment)
+	DependenciesGrouped []EnvironmentGroup
 }
 
 // Set up a cache for the getDependencies function
@@ -83,6 +85,11 @@ type getDependenciesOutput struct {
 type GetDependenciesCache struct {
 	mtx  sync.RWMutex
 	data map[string]getDependenciesOutput
+}
+
+type EnvironmentGroup struct {
+	Environment string
+	Items       []string
 }
 
 func newGetDependenciesCache() *GetDependenciesCache {
@@ -396,12 +403,39 @@ func createProject(sourcePath string) (*DependencyDirs, error) {
 		relativeDependencies = append(relativeDependencies, strings.Split(absolutePath, gitRoot)[1])
 	}
 
+	// Group by environment
+	relativeDependenciesGrouped := groupByEnvironment(relativeDependencies)	
+
 	project := &DependencyDirs{
 		SourcePath:   relativeSourceDir,
 		Dependencies: relativeDependencies,
+		DependenciesGrouped: relativeDependenciesGrouped,
 	}
 
 	return project, nil
+}
+
+func groupByEnvironment(list []string) []EnvironmentGroup {
+	groups := make(map[string][]string)
+
+	for _, item := range list {
+		parts := strings.SplitN(item, "/", 2)
+		environment := "root"
+		if len(parts) > 1 {
+			environment = parts[0]
+		}
+		groups[environment] = append(groups[environment], item)
+	}
+
+	var result []EnvironmentGroup
+	for environment, items := range groups {
+		result = append(result, EnvironmentGroup{
+			Environment: environment,
+			Items:       items,
+		})
+	}
+
+	return result
 }
 
 // Finds the absolute paths of all terragrunt.hcl files

--- a/test/inputs/.gitlab-ci.yml.tpl
+++ b/test/inputs/.gitlab-ci.yml.tpl
@@ -52,4 +52,12 @@ Apply {{ .SourcePath }}:
         {{- range .Dependencies }}
         - {{ . -}}
         {{ end }}
+    {{/* In case you exceed the 50 dependencies, you can group them by directory */}}        
+    {{/* {{- range .DependenciesGrouped }}
+    - when: manual
+      changes:
+      {{- range .Items }}
+        - {{ . }}
+      {{- end }}
+    {{ end }}    
 {{ end }}


### PR DESCRIPTION
This should fix (or work around) the issue I mentioned in #152 where `rules` can contain at most 50 files. 
With this new change you get access to `.DependenciesGrouped` and can loop through this, using the directory.

e.g. 

```yaml
  rules:
    {{- range .DependenciesGrouped }}
    - changes:
      {{- range .Items }}
        - {{ . }}
      {{- end }}
    {{ end }}
```

```
staging/example.hcl
production/example.hcl
foo.hcl
```

would end up in `root`, `staging` and `production` "environment groups". Each of them can contain 50 entries before Gitlab reaches its limits.